### PR TITLE
Added debug rendering for drawing lines and boxes. Using batch rendering

### DIFF
--- a/Arcane/Arcane.vcxproj
+++ b/Arcane/Arcane.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="src\Arcane\Animation\Bone.cpp" />
     <ClCompile Include="src\Arcane\Animation\PoseAnimator.cpp" />
     <ClCompile Include="src\Arcane\Editor\RendererStatsDisplay.cpp" />
+    <ClCompile Include="src\Arcane\Graphics\Renderer\DebugDraw3D.cpp" />
     <ClCompile Include="src\Arcane\Graphics\Renderer\Renderpass\EditorPass.cpp" />
     <ClCompile Include="src\Arcane\Graphics\Water\WaterManager.cpp" />
     <ClCompile Include="src\Arcane\RenderdocManager.cpp" />
@@ -267,6 +268,7 @@
     <ClInclude Include="src\Arcane\Animation\Bone.h" />
     <ClInclude Include="src\Arcane\Animation\PoseAnimator.h" />
     <ClInclude Include="src\Arcane\Editor\RendererStatsDisplay.h" />
+    <ClInclude Include="src\Arcane\Graphics\Renderer\DebugDraw3D.h" />
     <ClInclude Include="src\Arcane\Graphics\Renderer\Renderpass\EditorPass.h" />
     <ClInclude Include="src\Arcane\Graphics\Water\WaterManager.h" />
     <ClInclude Include="src\Arcane\RenderdocManager.h" />
@@ -359,6 +361,7 @@
   <ItemGroup>
     <None Include="src\Arcane\Shaders\2D\UnlitSprite.glsl" />
     <None Include="src\Arcane\Shaders\ColourWriteSkinned.glsl" />
+    <None Include="src\Arcane\Shaders\DebugLine.glsl" />
     <None Include="src\Arcane\Shaders\Deferred\PBR_Skinned_Model_GeometryPass.glsl" />
     <None Include="src\Arcane\Shaders\Forward\PBR_Skinned_Model.glsl" />
     <None Include="src\Arcane\Shaders\Outline.glsl" />

--- a/Arcane/Arcane.vcxproj.filters
+++ b/Arcane/Arcane.vcxproj.filters
@@ -73,6 +73,7 @@
     <ClCompile Include="src\Arcane\Editor\RendererStatsDisplay.cpp" />
     <ClCompile Include="src\Arcane\Platform\OpenGL\GPUTimerManager.cpp" />
     <ClCompile Include="src\Arcane\Graphics\Water\WaterManager.cpp" />
+    <ClCompile Include="src\Arcane\Graphics\Renderer\DebugDraw3D.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Arcane\RenderdocManager.h" />
@@ -168,6 +169,7 @@
     <ClInclude Include="src\Arcane\Editor\RendererStatsDisplay.h" />
     <ClInclude Include="src\Arcane\Platform\OpenGL\GPUTimerManager.h" />
     <ClInclude Include="src\Arcane\Graphics\Water\WaterManager.h" />
+    <ClInclude Include="src\Arcane\Graphics\Renderer\DebugDraw3D.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\awesomeface.png" />
@@ -231,5 +233,6 @@
     <None Include="src\Arcane\Shaders\Shadowmap_Generation_Skinned.glsl" />
     <None Include="src\Arcane\Shaders\Shadowmap_Generation_Linear_Skinned.glsl" />
     <None Include="src\Arcane\Shaders\ColourWriteSkinned.glsl" />
+    <None Include="src\Arcane\Shaders\DebugLine.glsl" />
   </ItemGroup>
 </Project>

--- a/Arcane/src/Arcane/Core/Application.cpp
+++ b/Arcane/src/Arcane/Core/Application.cpp
@@ -13,6 +13,7 @@
 #include <Arcane/ImGui/ImGuiLayer.h>
 #include <Arcane/RenderdocManager.h>
 #include <Arcane/Input/InputManager.h>
+#include <Arcane/Graphics/Renderer/DebugDraw3D.h>
 
 #include "glfw/glfw3native.h"
 
@@ -37,9 +38,9 @@ namespace Arcane
 		m_Window = new Window(this, specification);
 		m_Window->Init();
 		m_AssetManager = &Arcane::AssetManager::GetInstance(); // Need to initialize the asset manager early so we can load resources and have our worker threads instantiated
+		Arcane::ShaderLoader::SetShaderFilepath("../Arcane/src/Arcane/shaders/");
 		Renderer::Init(); // Must be loaded before textures get created since they query for the max anistropy from the renderer
 		Arcane::TextureLoader::InitializeDefaultTextures();
-		Arcane::ShaderLoader::SetShaderFilepath("../Arcane/src/Arcane/shaders/");
 		m_ActiveScene = new Scene(m_Window);
 		m_MasterRenderPass = new MasterRenderPass(m_ActiveScene);
 		m_InputManager = &InputManager::GetInstance();

--- a/Arcane/src/Arcane/Graphics/Renderer/DebugDraw3D.cpp
+++ b/Arcane/src/Arcane/Graphics/Renderer/DebugDraw3D.cpp
@@ -1,0 +1,104 @@
+#include "arcpch.h"
+#include "DebugDraw3D.h"
+
+#include <Arcane/Graphics/Shader.h>
+#include <Arcane/Platform/OpenGL/VertexArray.h>
+#include <Arcane/Platform/OpenGL/Buffer.h>
+#include <Arcane/Util/Loaders/ShaderLoader.h>
+#include <Arcane/Graphics/Renderer/GLCache.h>
+#include <Arcane/Graphics/Camera/ICamera.h>
+
+namespace Arcane
+{
+	GLCache *DebugDraw3D::s_GLCache = nullptr;
+	Shader *DebugDraw3D::s_LineShader = nullptr;
+	VertexArray *DebugDraw3D::s_LineVertexArray = nullptr;
+	Buffer *DebugDraw3D::s_LineVertexBuffer = nullptr;
+	uint32_t DebugDraw3D::s_LineVertexCount = 0;
+	LineVertex *DebugDraw3D::s_LineVertexBufferBase = nullptr;
+	LineVertex *DebugDraw3D::s_LineVertexBufferPtr = nullptr;
+	float DebugDraw3D::s_LineThickness = 3.0f;
+
+	void DebugDraw3D::Init()
+	{
+		s_GLCache = GLCache::GetInstance();
+		s_LineShader = ShaderLoader::LoadShader("DebugLine.glsl");
+		s_LineVertexArray = new VertexArray();
+		s_LineVertexBuffer = new Buffer(s_MaxLineVertices * sizeof(LineVertex)); // Dynamic GPU Data that can we can update with our current s_LineVertexBuffer
+		s_LineVertexBuffer->SetComponentCount(3);
+		s_LineVertexArray->AddBuffer(s_LineVertexBuffer, 0, 6 * sizeof(float), 0);
+		s_LineVertexArray->AddBuffer(s_LineVertexBuffer, 1, 6 * sizeof(float), 3 * sizeof(float));
+		s_LineVertexBufferBase = new LineVertex[s_MaxLineVertices];
+	}
+
+	void DebugDraw3D::BeginBatch()
+	{
+		s_LineVertexCount = 0;
+		s_LineVertexBufferPtr = s_LineVertexBufferBase;
+	}
+
+	void DebugDraw3D::FlushBatch(ICamera *camera)
+	{
+		if (s_LineVertexCount)
+		{
+			uint32_t dataSize = (uint32_t)((uint8_t*)s_LineVertexBufferPtr - (uint8_t*)s_LineVertexBufferBase);
+			s_LineVertexBuffer->SetData(s_LineVertexBufferBase, dataSize);
+
+			s_GLCache->SetLineSmooth(true);
+			s_GLCache->SetLineWidth(s_LineThickness);
+			s_GLCache->SetShader(s_LineShader);
+			s_LineShader->SetUniform("viewProjection", camera->GetProjectionMatrix() * camera->GetViewMatrix());
+			s_LineVertexArray->Bind();
+			glDrawArrays(GL_LINES, 0, s_LineVertexCount);
+		}
+	}
+
+	void DebugDraw3D::QueueLine(const glm::vec3 &lineStart, const glm::vec3 &lineEnd, const glm::vec3 &colour)
+	{
+		if (s_LineVertexCount >= s_MaxLineVertices)
+		{
+			ARC_ASSERT(false, "DebugDraw3D hit line limit, won't render additional lines. Up the limit if you need it!");
+			return;
+		}
+
+		s_LineVertexBufferPtr->Position = lineStart;
+		s_LineVertexBufferPtr->Colour = colour;
+		s_LineVertexBufferPtr++;
+
+		s_LineVertexBufferPtr->Position = lineEnd;
+		s_LineVertexBufferPtr->Colour = colour;
+		s_LineVertexBufferPtr++;
+
+		s_LineVertexCount += 2;
+	}
+
+	void DebugDraw3D::QueueBox(const glm::vec3 &boxPos, const glm::vec3 &boxScale, const glm::vec3 &colour)
+	{
+		glm::vec3 boxScaleHalf = boxScale * 0.5f;
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z - boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z - boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z - boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z - boxScaleHalf.z), colour);
+
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z + boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z + boxScaleHalf.z), glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z + boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z + boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y - boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+
+		QueueLine(glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x - boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+		QueueLine(glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z - boxScaleHalf.z), glm::vec3(boxPos.x + boxScaleHalf.x, boxPos.y + boxScaleHalf.y, boxPos.z + boxScaleHalf.z), colour);
+	}
+
+	void DebugDraw3D::QueueBox(const glm::mat4 &transform, const glm::vec3 &colour)
+	{
+
+	}
+
+	void DebugDraw3D::SetLineThickness(float thickness)
+	{
+		s_LineThickness = thickness;
+	}
+}

--- a/Arcane/src/Arcane/Graphics/Renderer/DebugDraw3D.h
+++ b/Arcane/src/Arcane/Graphics/Renderer/DebugDraw3D.h
@@ -1,0 +1,52 @@
+#pragma once
+#ifndef DEBUGDRAW3D_H
+#define DEBUGDRAW3D_H
+
+/*
+	This class can be used to render lines and shapes. This should not be used for gameplay purposes, because it isn't performant and the lines aren't anti aliased properly
+	They are just lines for debugging purposes, displaying debug information in the editor, or scripting purposes when testing raycasts and other things
+*/
+
+namespace Arcane
+{
+	class ICamera;
+	class GLCache;
+	class Shader;
+	class VertexArray;
+	class Buffer;
+
+	struct LineVertex
+	{
+		glm::vec3 Position;
+		glm::vec3 Colour;
+	};
+
+	class DebugDraw3D
+	{
+	public:
+		static void Init();
+
+		static void BeginBatch();
+		static void FlushBatch(ICamera *camera);
+
+		static void QueueLine(const glm::vec3 &lineStart, const glm::vec3 &lineEnd, const glm::vec3 &colour);
+		static void QueueBox(const glm::vec3 &boxPos, const glm::vec3 &boxScale, const glm::vec3 &colour);
+		static void QueueBox(const glm::mat4 &transform, const glm::vec3 &colour);
+
+		static void SetLineThickness(float thickness);
+	private:
+		static GLCache *s_GLCache;
+		
+		static Shader *s_LineShader;
+		static VertexArray *s_LineVertexArray;
+		static Buffer *s_LineVertexBuffer;
+		static uint32_t s_LineVertexCount;
+		static LineVertex *s_LineVertexBufferBase;
+		static LineVertex *s_LineVertexBufferPtr;
+
+		static const uint32_t s_MaxLineVertices = 2000; // 1000 lines limit (can be jacked up or re-visited to resize properly)
+		static float s_LineThickness;
+	};
+}
+
+#endif

--- a/Arcane/src/Arcane/Graphics/Renderer/GLCache.cpp
+++ b/Arcane/src/Arcane/Graphics/Renderer/GLCache.cpp
@@ -14,13 +14,16 @@ namespace Arcane
 		m_FaceToCull = GL_BACK;
 		m_Multisample = false;
 		m_UsesClipPlane = false;
+		m_LineSmooth = false;
 		SetDepthTest(true);
 		SetFaceCull(true);
 		SetClipPlane(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f));
+		SetLineSmooth(true);
 		m_RedMask = GL_TRUE;
 		m_GreenMask = GL_TRUE;
 		m_BlueMask = GL_TRUE;
 		m_AlphaMask = GL_TRUE;
+		m_LineThickness = -1.0f;
 	}
 
 	GLCache::~GLCache() {
@@ -94,6 +97,18 @@ namespace Arcane
 		}
 	}
 
+	void GLCache::SetLineSmooth(bool choice)
+	{
+		if (m_LineSmooth != choice)
+		{
+			m_LineSmooth = choice;
+			if (m_LineSmooth)
+				glEnable(GL_LINE_SMOOTH);
+			else
+				glDisable(GL_LINE_SMOOTH);
+		}
+	}
+
 	void GLCache::SetDepthFunc(GLenum depthFunc) {
 		if (m_DepthFunc != depthFunc) {
 			m_DepthFunc = depthFunc;
@@ -158,6 +173,15 @@ namespace Arcane
 	void GLCache::SetClipPlane(glm::vec4 clipPlane)
 	{
 		m_ActiveClipPlane = clipPlane;
+	}
+
+	void GLCache::SetLineWidth(float lineThickness)
+	{
+		if (m_LineThickness != lineThickness)
+		{
+			m_LineThickness = lineThickness;
+			glLineWidth(m_LineThickness);
+		}
 	}
 
 	void GLCache::SetShader(Shader *shader) {

--- a/Arcane/src/Arcane/Graphics/Renderer/GLCache.h
+++ b/Arcane/src/Arcane/Graphics/Renderer/GLCache.h
@@ -23,6 +23,7 @@ namespace Arcane
 		void SetFaceCull(bool choice);
 		void SetMultisample(bool choice);
 		void SetUsesClipPlane(bool choice);
+		void SetLineSmooth(bool choice);
 
 		void SetDepthFunc(GLenum depthFunc);
 		void SetStencilFunc(GLenum testFunc, int stencilFragValue, unsigned int stencilBitmask = 0xFF);
@@ -32,6 +33,7 @@ namespace Arcane
 		void SetBlendFunc(GLenum src, GLenum dst);
 		void SetCullFace(GLenum faceToCull);
 		void SetClipPlane(glm::vec4 clipPlane);
+		void SetLineWidth(float lineThickness);
 
 		void SetShader(Shader *shader);
 		void SetShader(unsigned int shaderID);
@@ -46,6 +48,7 @@ namespace Arcane
 		bool m_Cull;
 		bool m_Multisample;
 		bool m_UsesClipPlane;
+		bool m_LineSmooth;
 
 		// Depth State
 		GLenum m_DepthFunc;
@@ -69,6 +72,9 @@ namespace Arcane
 
 		// Clip Plane State
 		glm::vec4 m_ActiveClipPlane;
+
+		// Line Thickness
+		float m_LineThickness;
 
 		// Active binds
 		unsigned int m_ActiveShaderID;

--- a/Arcane/src/Arcane/Graphics/Renderer/Renderer.cpp
+++ b/Arcane/src/Arcane/Graphics/Renderer/Renderer.cpp
@@ -8,6 +8,7 @@
 #include <Arcane/Graphics/Mesh/Common/Quad.h>
 #include <Arcane/Graphics/Camera/ICamera.h>
 #include <Arcane/Animation/PoseAnimator.h>
+#include <Arcane/Graphics/Renderer/DebugDraw3D.h>
 
 namespace Arcane
 {
@@ -35,6 +36,8 @@ namespace Arcane
 
 		s_NdcPlane = new Quad();
 		s_NdcCube = new Cube();
+
+		DebugDraw3D::Init();
 	}
 
 	void Renderer::Shutdown()
@@ -47,6 +50,8 @@ namespace Arcane
 		m_CurrentDrawCallCount = 0;
 		m_CurrentMeshesDrawnCount = 0;
 		m_CurrentQuadsDrawnCount = 0;
+
+		DebugDraw3D::BeginBatch();
 	}
 
 	void Renderer::EndFrame()

--- a/Arcane/src/Arcane/Graphics/Renderer/Renderpass/EditorPass.cpp
+++ b/Arcane/src/Arcane/Graphics/Renderer/Renderpass/EditorPass.cpp
@@ -32,7 +32,7 @@ namespace Arcane
 		EditorPassOutput output;
 		output.outFramebuffer = sceneFramebuffer;
 
-		// Entity highlighting
+		// Entity highlighting (should be done first since it might use debug rendering to highlight objects if no mesh exists to highlight)
 		if (m_FocusedEntity.IsValid() && m_FocusedEntity.HasComponent<MeshComponent>())
 		{
 			auto& meshComponent = m_FocusedEntity.GetComponent<MeshComponent>();
@@ -88,6 +88,12 @@ namespace Arcane
 
 			output.outFramebuffer = extraFramebuffer2; // Update the output framebuffer
 		}
+		else if (m_FocusedEntity.IsValid() && m_FocusedEntity.HasComponent<TransformComponent>())
+		{
+			auto& transformComponent = m_FocusedEntity.GetComponent<TransformComponent>();
+
+			DebugDraw3D::QueueBox(transformComponent.Translation, transformComponent.Scale, m_OutlineColour);
+		}
 
 		// DebugDraw3D
 		{
@@ -99,9 +105,6 @@ namespace Arcane
 			m_GLCache->SetStencilTest(false);
 			m_GLCache->SetBlend(false);
 			m_GLCache->SetMultisample(false);
-
-			DebugDraw3D::QueueLine(glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(-7.48f, -7.6f, -31.40f), glm::vec3(1.0f, 0.0f, 0.0f));
-			DebugDraw3D::QueueBox(glm::vec3(-86.9f, -5.0f, -28.2f), glm::vec3(10.0f, 10.0f, 10.0f), glm::vec3(0.0f, 0.0f, 1.0f));
 
 			DebugDraw3D::FlushBatch(camera);
 		}

--- a/Arcane/src/Arcane/Graphics/Renderer/Renderpass/EditorPass.cpp
+++ b/Arcane/src/Arcane/Graphics/Renderer/Renderpass/EditorPass.cpp
@@ -7,6 +7,7 @@
 #include <Arcane/Graphics/Renderer/Renderer.h>
 #include <Arcane/Util/Loaders/AssetManager.h>
 #include <Arcane/Scene/Scene.h>
+#include <Arcane/Graphics/Renderer/DebugDraw3D.h>
 
 namespace Arcane
 {
@@ -88,7 +89,24 @@ namespace Arcane
 			output.outFramebuffer = extraFramebuffer2; // Update the output framebuffer
 		}
 
-		// Debug Light Drawing
+		// DebugDraw3D
+		{
+			glViewport(0, 0, output.outFramebuffer->GetWidth(), output.outFramebuffer->GetHeight());
+			output.outFramebuffer->Bind();
+
+			// Setup state
+			m_GLCache->SetDepthTest(false);
+			m_GLCache->SetStencilTest(false);
+			m_GLCache->SetBlend(false);
+			m_GLCache->SetMultisample(false);
+
+			DebugDraw3D::QueueLine(glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(-7.48f, -7.6f, -31.40f), glm::vec3(1.0f, 0.0f, 0.0f));
+			DebugDraw3D::QueueBox(glm::vec3(-86.9f, -5.0f, -28.2f), glm::vec3(10.0f, 10.0f, 10.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+
+			DebugDraw3D::FlushBatch(camera);
+		}
+
+		// Debug Light Drawing (can clear depth so do this last)
 		{
 			glViewport(0, 0, output.outFramebuffer->GetWidth(), output.outFramebuffer->GetHeight());
 			output.outFramebuffer->Bind();

--- a/Arcane/src/Arcane/Platform/OpenGL/Buffer.cpp
+++ b/Arcane/src/Arcane/Platform/OpenGL/Buffer.cpp
@@ -8,6 +8,14 @@ namespace Arcane
 		glGenBuffers(1, &m_BufferID);
 	}
 
+	// Can be used to allocate a big buffer then you can use SetData to vary its size
+	Buffer::Buffer(uint32_t size)
+	{
+		glGenBuffers(1, &m_BufferID);
+		Bind();
+		glBufferData(GL_ARRAY_BUFFER, size, nullptr, GL_DYNAMIC_DRAW); // Dynamic since this will change size and what were drawing
+	}
+
 	Buffer::Buffer(float *data, int amount, unsigned int componentCount)
 	{
 		glGenBuffers(1, &m_BufferID);
@@ -17,6 +25,12 @@ namespace Arcane
 	Buffer::~Buffer()
 	{
 		glDeleteBuffers(1, &m_BufferID);
+	}
+
+	void Buffer::SetData(const void *data, uint32_t size)
+	{
+		Bind();
+		glBufferSubData(GL_ARRAY_BUFFER, 0, size, data);
 	}
 
 	void Buffer::Load(float *data, int amount, unsigned int componentCount)

--- a/Arcane/src/Arcane/Platform/OpenGL/Buffer.h
+++ b/Arcane/src/Arcane/Platform/OpenGL/Buffer.h
@@ -8,14 +8,18 @@ namespace Arcane
 	{
 	public:
 		Buffer();
+		Buffer(uint32_t size); // Can be used to allocate a big buffer then you can use SetData to vary its size
 		Buffer(float *data, int amount, unsigned int componentCount);
 		~Buffer();
 
+		// Should use one, or the other depending on how this buffer is being used (statically vs dynamically which is 'Load()' vs 'SetData()' respectively)
+		void SetData(const void *data, uint32_t size);
 		void Load(float *data, int amount, unsigned int componentCount);
 
 		void Bind() const;
 		void Unbind() const;
 
+		inline void SetComponentCount(unsigned int count) { m_ComponentCount = count; }
 		inline unsigned int GetComponentCount() const { return m_ComponentCount; }
 	private:
 		unsigned int m_BufferID;

--- a/Arcane/src/Arcane/Platform/OpenGL/VertexArray.cpp
+++ b/Arcane/src/Arcane/Platform/OpenGL/VertexArray.cpp
@@ -20,13 +20,13 @@ namespace Arcane
 		glDeleteVertexArrays(1, &m_VertexArrayID);
 	}
 
-	void VertexArray::AddBuffer(Buffer *buffer, int index)
+	void VertexArray::AddBuffer(Buffer *buffer, int index, size_t stride /* = 0*/, size_t offset /*= 0*/)
 	{
 		Bind();
 
 		buffer->Bind();
 		glEnableVertexAttribArray(index);
-		glVertexAttribPointer(index, buffer->GetComponentCount(), GL_FLOAT, GL_FALSE, 0, 0);
+		glVertexAttribPointer(index, buffer->GetComponentCount(), GL_FLOAT, GL_FALSE, static_cast<GLsizei>(stride), (void*)offset);
 		buffer->Unbind();
 
 		Unbind();

--- a/Arcane/src/Arcane/Platform/OpenGL/VertexArray.h
+++ b/Arcane/src/Arcane/Platform/OpenGL/VertexArray.h
@@ -13,7 +13,7 @@ namespace Arcane
 		~VertexArray();
 
 		// Function for automatically adding non-interleaved buffer data
-		void AddBuffer(Buffer *buffer, int index);
+		void AddBuffer(Buffer *buffer, int index, size_t stride = 0, size_t offset = 0);
 
 		void Bind() const;
 		void Unbind() const;

--- a/Arcane/src/Arcane/Shaders/DebugLine.glsl
+++ b/Arcane/src/Arcane/Shaders/DebugLine.glsl
@@ -1,0 +1,30 @@
+#shader-type vertex
+#version 430 core
+
+layout (location = 0) in vec3 position;
+layout (location = 1) in vec3 colour;
+
+out vec3 LineColour;
+
+uniform mat4 viewProjection;
+
+void main()
+{
+	LineColour = colour;
+	gl_Position = viewProjection * vec4(position, 1.0);
+}
+
+
+
+
+#shader-type fragment
+#version 430 core
+
+in vec3 LineColour;
+
+out vec4 FragColour;
+
+void main()
+{
+	FragColour = vec4(LineColour, 1.0);
+}


### PR DESCRIPTION
Should only be used for debugging purposes. This can also be used for highlighting a light source in the edtior, since our current approach just outlines a mesh, but lights have no mesh to outline.